### PR TITLE
Revert "Bump nokogiri from 1.15.4 to 1.16.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.4)
     minitest (5.20.0)
     net-imap (0.3.7)
       date
@@ -108,10 +108,10 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     nio4r (2.5.9)
-    nokogiri (1.16.2)
+    nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    racc (1.7.3)
+    racc (1.7.1)
     rack (2.2.8)
     rack-test (2.1.0)
       rack (>= 1.3)


### PR DESCRIPTION
Reverts tanyakho/numbergossip#28

Nokogiri 1.16 dropped support for Ruby 2.7, so we need to migrate before adopting this.